### PR TITLE
Remove type: module from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "lint": "standard",
     "test": "yarn lint && jest"
   },
-  "type": "module",
   "keywords": [
     "generate",
     "generator",


### PR DESCRIPTION
type: module is intended for ECMAScript modules, but this package uses the CommonJS `export` syntax.

This didn't seem to cause any issues until I upgraded to Webpack 5, where it refuses to properly import this library. Removing this line allows imports to work properly.

I've tested and, once this line is removed, you can import this package using either CJS or ECMAScript import syntax